### PR TITLE
pthread_detach

### DIFF
--- a/LoRa.c
+++ b/LoRa.c
@@ -204,6 +204,7 @@ void rxDoneISRf(int gpio_n, int level, uint32_t tick, void *modemptr){
         lora_get_snr(modem);
         lora_reset_irq_flags(modem->spid);
         pthread_create(&(modem->rx.cbThread), NULL, startRxCallback, (void *)(modem));
+	pthread_detach(modem->rx.cbThread);
     }
 }
 
@@ -220,6 +221,7 @@ void txDoneISRf(int gpio_n, int level, uint32_t tick, void *modemptr){
         lora_reset_irq_flags(modem->spid);
         lora_set_satandby_mode(modem->spid);
         pthread_create(&(modem->tx.cbThread), NULL, startTxCallback, (void *)(modem));
+	pthread_detach(modem->tx.cbThread);
     }
 }
 


### PR DESCRIPTION
Invoke pthread_detach after pthread_create as LoRa does not do a pthread_join() on thre created threads.